### PR TITLE
Fixed missing LittleBag tooltip for sub-block quantities

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/gui/controls/GuiSlotControlBlockIngredient.java
+++ b/src/main/java/com/creativemd/littletiles/common/gui/controls/GuiSlotControlBlockIngredient.java
@@ -48,6 +48,7 @@ public class GuiSlotControlBlockIngredient extends GuiSlotControl {
 			if (pixel > 0)
 				line += (Math.round(pixel * 100) / 100) + " pixel";
 			tooltip.add(line);
+			return tooltip;
 		}
 		return super.getTooltip();
 	}


### PR DESCRIPTION
Fixes CreativeMD/LittleTiles#229

Does not regress bag crash, the fix for which caused this bug.