### PR TITLE
Fix crash when using the hammer

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/action/LittleAction.java
+++ b/src/main/java/com/creativemd/littletiles/common/action/LittleAction.java
@@ -271,8 +271,8 @@ public abstract class LittleAction extends CreativeCorePacket {
 			if (tiles != null && tiles.size() > 0) {
 				world.setBlockState(pos, BlockTile.getState(tiles));
 				TileEntityLittleTiles te = (TileEntityLittleTiles) world.getTileEntity(pos);
-				((TileEntityLittleTiles) tileEntity).convertTo(context);
-				((TileEntityLittleTiles) tileEntity).updateTiles((x) -> {
+				((TileEntityLittleTiles) te).convertTo(context);
+				((TileEntityLittleTiles) te).updateTiles((x) -> {
 					for (LittleTile tile : tiles) {
 						tile.te = te;
 						tile.place(x);

--- a/src/main/java/com/creativemd/littletiles/common/action/LittleAction.java
+++ b/src/main/java/com/creativemd/littletiles/common/action/LittleAction.java
@@ -271,8 +271,8 @@ public abstract class LittleAction extends CreativeCorePacket {
 			if (tiles != null && tiles.size() > 0) {
 				world.setBlockState(pos, BlockTile.getState(tiles));
 				TileEntityLittleTiles te = (TileEntityLittleTiles) world.getTileEntity(pos);
-				((TileEntityLittleTiles) te).convertTo(context);
-				((TileEntityLittleTiles) te).updateTiles((x) -> {
+				te.convertTo(context);
+				te.updateTiles((x) -> {
 					for (LittleTile tile : tiles) {
 						tile.te = te;
 						tile.place(x);


### PR DESCRIPTION
I updated to:
- LittleTiles_v1.5.0-pre170_mc1.12.2.jar
- CreativeCore_v1.9.70_mc1.12.2.jar

Then I placed a slice of glass and used the Little Hammer to remove it.

I hope this PR fixes the issue, but this commit looks to me like it should:
https://github.com/CreativeMD/LittleTiles/commit/d6f90a76e7f4cb697e0619c988b61a0955ac5115#diff-7561c08338b588fad6e6a0a1273ece4dR271-R281