### PR TITLE
Add update event which is fired after TileEntityLittleTiles#updateTiles(Consumer) is called

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/api/events/LittleTileUpdateEvent.java
+++ b/src/main/java/com/creativemd/littletiles/common/api/events/LittleTileUpdateEvent.java
@@ -1,0 +1,40 @@
+package com.creativemd.littletiles.common.api.events;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.WorldEvent;
+
+import java.util.Objects;
+
+public class LittleTileUpdateEvent extends WorldEvent {
+    private final BlockPos blockPos;
+
+    public LittleTileUpdateEvent(World world, BlockPos blockPos) {
+        super(world);
+        this.blockPos = blockPos;
+    }
+
+    public BlockPos getBlockPos() {
+        return blockPos;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LittleTileUpdateEvent that = (LittleTileUpdateEvent) o;
+        return Objects.equals(blockPos, that.blockPos);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(blockPos);
+    }
+
+    @Override
+    public String toString() {
+        return "LittleTileUpdateEvent{" +
+                "blockPos=" + blockPos +
+                '}';
+    }
+}

--- a/src/main/java/com/creativemd/littletiles/common/tileentity/TileEntityLittleTiles.java
+++ b/src/main/java/com/creativemd/littletiles/common/tileentity/TileEntityLittleTiles.java
@@ -21,6 +21,7 @@ import com.creativemd.littletiles.client.render.cache.BlockLayerRenderBuffer;
 import com.creativemd.littletiles.client.render.cache.RenderCubeLayerCache;
 import com.creativemd.littletiles.client.render.cache.RenderingThread;
 import com.creativemd.littletiles.client.render.world.LittleChunkDispatcher;
+import com.creativemd.littletiles.common.api.events.LittleTileUpdateEvent;
 import com.creativemd.littletiles.common.api.te.ILittleTileTE;
 import com.creativemd.littletiles.common.blocks.BlockTile;
 import com.creativemd.littletiles.common.mods.chiselsandbits.ChiselsAndBitsManager;
@@ -52,6 +53,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Optional.Interface;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.relauncher.Side;
@@ -268,6 +270,8 @@ public class TileEntityLittleTiles extends TileEntityCreative implements ILittle
 	public void updateTiles(Consumer<TileList> action) {
 		action.accept(tiles);
 		updateTiles();
+
+		MinecraftForge.EVENT_BUS.post(new LittleTileUpdateEvent(getWorld(), getPos()));
 	}
 	
 	/** Block will not update */


### PR DESCRIPTION
This was the original point of the first PR I made. Could you please merge this to allow compatibility with external mods? And could you give me an update when a prerelease containing these changes is released on curseforge? I wasn't able to reproduce a working build without gradle.

Thanks in advance