### PR TITLE
Fixed spamming `Tileentity is not loaded yet` error

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/render/cache/RenderingThread.java
+++ b/src/main/java/com/creativemd/littletiles/client/render/cache/RenderingThread.java
@@ -328,15 +328,15 @@ public class RenderingThread extends Thread {
                             if (LittleTilesProfilerOverlay.isActive())
                                 LittleTilesProfilerOverlay.finishBuildingCache(System.nanoTime() - duration);
                         } catch (Exception e) {
-                            if (!(e instanceof RenderingException))
-                                e.printStackTrace();
+                            e.printStackTrace();
                             if (!finish(data, -1, false))
                                 updateCoords.add(data);
                         }
                     } catch (InvalidTileEntityException e) {
                         finish(data, -1, true);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        if (!(e instanceof RenderingException))
+                            e.printStackTrace();
                         updateCoords.add(data);
                     } catch (OutOfMemoryError error) {
                         updateCoords.add(data);


### PR DESCRIPTION
`RenderingException` check was in wrong try-catch