### PR TITLE
Fixed ColoredLux "forgetting" about the block handlers after reload

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/mod/lux/LuxExtension.java
+++ b/src/main/java/com/creativemd/littletiles/common/mod/lux/LuxExtension.java
@@ -2,7 +2,10 @@ package com.creativemd.littletiles.common.mod.lux;
 
 import java.util.List;
 
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.zeith.lux.api.LuxManager;
+import org.zeith.lux.api.event.ReloadLuxManagerEvent;
 import org.zeith.lux.api.light.ILightBlockHandler;
 
 import com.creativemd.creativecore.common.utils.mc.ColorUtils;
@@ -17,34 +20,38 @@ import com.zeitheron.hammercore.api.lighting.ColoredLight;
 import net.minecraft.tileentity.TileEntity;
 
 public class LuxExtension {
-    
-    public static void init() {
-        ILightBlockHandler handler = (world, pos, state, e) -> {
-            
-            TileEntity tileEntity = world.getTileEntity(pos);
-            if (tileEntity instanceof TileEntityLittleTiles) {
-                TileEntityLittleTiles te = (TileEntityLittleTiles) tileEntity;
-                
-                for (Pair<IParentTileList, LittleTile> pair : te.allTiles()) {
-                    LittleTile tile = pair.value;
-                    List<ColoredLight> lights = LuxManager.getLights(world, pos, tile.getBlockState(), null, e.getPartialTicks());
-                    if (lights.isEmpty())
-                        continue;
-                    for (ColoredLight light : lights) {
-                        int color = ColorUtils.RGBAToInt(light.r, light.g, light.b, light.a);
-                        if (tile instanceof LittleTileColored)
-                            color = ColorUtils.blend(color, ((LittleTileColored) tile).color);
-                        e.add(ColoredLight.builder().pos(tile.getCompleteBox().getBox(te.getContext(), te.getPos()).getCenter())
-                            .color(ColorUtils.getRedDecimal(color), ColorUtils.getGreenDecimal(color), ColorUtils.getBlueDecimal(color), ColorUtils.getAlphaDecimal(color))
-                            .radius((float) (light.radius * tile.getPercentVolume(te.getContext()))));
-                    }
-                }
-            }
-        };
-        LuxManager.registerBlockLight(LittleTiles.blockTileNoTicking, handler);
-        LuxManager.registerBlockLight(LittleTiles.blockTileNoTickingRendered, handler);
-        LuxManager.registerBlockLight(LittleTiles.blockTileTicking, handler);
-        LuxManager.registerBlockLight(LittleTiles.blockTileTickingRendered, handler);
-    }
-    
+
+	public static void init() {
+		MinecraftForge.EVENT_BUS.register(LuxExtension.class);
+	}
+
+	@SubscribeEvent
+	public static void reloadLuxManager(ReloadLuxManagerEvent event) {
+		ILightBlockHandler handler = (world, pos, state, e) -> {
+
+			TileEntity tileEntity = world.getTileEntity(pos);
+			if (tileEntity instanceof TileEntityLittleTiles) {
+				TileEntityLittleTiles te = (TileEntityLittleTiles) tileEntity;
+
+				for (Pair<IParentTileList, LittleTile> pair : te.allTiles()) {
+					LittleTile tile = pair.value;
+					List<ColoredLight> lights = LuxManager.getLights(world, pos, tile.getBlockState(), null, e.getPartialTicks());
+					if (lights.isEmpty())
+						continue;
+					for (ColoredLight light : lights) {
+						int color = ColorUtils.RGBAToInt(light.r, light.g, light.b, light.a);
+						if (tile instanceof LittleTileColored)
+							color = ColorUtils.blend(color, ((LittleTileColored) tile).color);
+						e.add(ColoredLight.builder().pos(tile.getCompleteBox().getBox(te.getContext(), te.getPos()).getCenter())
+								.color(ColorUtils.getRedDecimal(color), ColorUtils.getGreenDecimal(color), ColorUtils.getBlueDecimal(color), ColorUtils.getAlphaDecimal(color))
+								.radius((float) (light.radius * tile.getPercentVolume(te.getContext()))));
+					}
+				}
+			}
+		};
+		event.registerBlockLight(LittleTiles.blockTileNoTicking, handler);
+		event.registerBlockLight(LittleTiles.blockTileNoTickingRendered, handler);
+		event.registerBlockLight(LittleTiles.blockTileTicking, handler);
+		event.registerBlockLight(LittleTiles.blockTileTickingRendered, handler);
+	}
 }


### PR DESCRIPTION
ColoredLux reloads the light system in a few cases, including boot, world load, and `/lux reload`, this resets a list of registered block and entity light handlers.
To avoid having troubles with this, instead of registering block handlers during `init`, a better way would be to tell MCF EVENT_BUS to register the extension class for events, and register the block light handlers within the `reloadLuxManager`.