### PR TITLE
Fix to LittleStorage filled value

### DIFF
--- a/src/main/java/com/creativemd/littletiles/common/structure/type/LittleStorage.java
+++ b/src/main/java/com/creativemd/littletiles/common/structure/type/LittleStorage.java
@@ -116,7 +116,7 @@ public class LittleStorage extends LittleStructure {
         for (int i = 0; i < previews.size(); i++) {
             if (previews.get(i).getBlockName().equals(name))
                 size += previews.get(i).box.getSize()
-                    .getPercentVolume(previews.getContext()) * LittleGridContext.get().maxTilesPerBlock * LittleTiles.CONFIG.general.storagePerPixel;
+                        .getPercentVolume(previews.getContext()) * LittleGridContext.get().maxTilesPerBlock * LittleTiles.CONFIG.general.storagePerPixel;
         }
         return (int) size;
     }
@@ -143,17 +143,11 @@ public class LittleStorage extends LittleStructure {
         if (getWorld().isRemote)
             return;
         int used = 0;
-        boolean allSlotsFilled = true;
         for (int i = 0; i < inventory.getSizeInventory(); i++) {
             ItemStack stack = inventory.getStackInSlot(i);
-            if (stack.isEmpty())
-                allSlotsFilled = false;
-            else
-                used += stack.getCount();
+            used += stack.getCount();
         }
-        if (allSlotsFilled)
-            used = inventorySize;
-        int filled = (int) (Math.ceil((double) used / inventorySize * 65535));
+        int filled = (int) (((double) used / (double) inventorySize) * 65535);
         getInput(1).updateState(BooleanUtils.toBits(filled, 16));
     }
     


### PR DESCRIPTION
Removed allSlotsFilled as it gives a premature filled value. For instance, if your inventory size is 128 and you have stored a total of 65 items. Even though it can hold 63 more of the same item, it is considered full.
Removed the Math.ceil from the filled. As it was not giving the correct value when I tested with it. With the ceil I was getting a value like "0000000111111111" when there was only one item left. When "1111111101111111" is the number you get without ceil, and there is only one item left. 