### PR TITLE
Option to prevent survival mode players from importing specified structure type

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/gui/SubGuiImport.java
+++ b/src/main/java/com/creativemd/littletiles/client/gui/SubGuiImport.java
@@ -9,6 +9,9 @@ import java.awt.datatransfer.Transferable;
 import com.creativemd.creativecore.common.gui.container.SubGui;
 import com.creativemd.creativecore.common.gui.controls.gui.GuiButton;
 import com.creativemd.creativecore.common.gui.controls.gui.GuiTextfield;
+import com.creativemd.littletiles.common.structure.registry.LittleStructureType;
+import com.creativemd.littletiles.common.tile.preview.LittlePreviews;
+import com.creativemd.littletiles.common.util.converation.StructureStringUtils;
 import com.creativemd.littletiles.common.util.grid.LittleGridContext;
 
 import net.minecraft.nbt.JsonToNBT;
@@ -35,11 +38,11 @@ public class SubGuiImport extends SubGui {
                 try {
                     textfield.text = (String) t.getTransferData(DataFlavor.stringFlavor);
                 } catch (Exception e) {
-                
+                    
                 }
             }
         });
-                
+        
         controls.add(new GuiButton("Import", 128, 52) {
             
             @Override
@@ -48,15 +51,39 @@ public class SubGuiImport extends SubGui {
                     NBTTagCompound nbt = JsonToNBT.getTagFromJson(textfield.text);
                     try {
                         LittleGridContext.get(nbt);
-                        sendPacketToServer(nbt);
+                        String name = canImport(LittlePreviews.getPreview(StructureStringUtils.importStructure(nbt), false));
+                        if (name.isEmpty())
+                            sendPacketToServer(nbt);
+                        else
+                            openButtonDialogDialog("Structure Type: " + name + " must be imported in creative mode.", "Ok");
                     } catch (RuntimeException e) {
                         openButtonDialogDialog("Invalid grid size " + nbt.getInteger("grid"), "Ok");
                     }
                 } catch (NBTException e) {
-                
+                    
                 }
             }
         });
     }
     
+    /** Gets the name of the structure type that is preventing the player from importing the structure in survival mode
+     * 
+     * @param previews
+     *            Previews that is looks through
+     * @return
+     *         The name of the structure that is preventing the player from importing */
+    private String canImport(LittlePreviews previews) {
+        LittleStructureType type = previews.getStructureType();
+        if (!type.canImport())
+            return type.id;
+        String typeName = "";
+        for (LittlePreviews child : previews.getChildren()) {
+            LittleStructureType typeChild = child.getStructureType();
+            if (!typeChild.canImport()) {
+                typeName = typeChild.id;
+                break;
+            }
+        }
+        return typeName;
+    }
 }

--- a/src/main/java/com/creativemd/littletiles/client/gui/SubGuiImport.java
+++ b/src/main/java/com/creativemd/littletiles/client/gui/SubGuiImport.java
@@ -77,13 +77,9 @@ public class SubGuiImport extends SubGui {
         if (!type.canImport())
             return type.id;
         String typeName = "";
-        for (LittlePreviews child : previews.getChildren()) {
-            LittleStructureType typeChild = child.getStructureType();
-            if (!typeChild.canImport()) {
-                typeName = typeChild.id;
-                break;
-            }
-        }
+        for (LittlePreviews child : previews.getChildren())
+            typeName = canImport(child);
+        
         return typeName;
     }
 }

--- a/src/main/java/com/creativemd/littletiles/common/structure/registry/LittleStructureType.java
+++ b/src/main/java/com/creativemd/littletiles/common/structure/registry/LittleStructureType.java
@@ -40,6 +40,7 @@ public class LittleStructureType {
     public final List<InternalComponent> inputs = new ArrayList<>();
     public final List<InternalComponentOutput> outputs = new ArrayList<>();
     protected List<IStructureIngredientRule> ingredientRules = null;
+    private boolean allowImport = true;
     
     public LittleStructureType(String id, String category, Class<? extends LittleStructure> structureClass, int attribute) {
         this.id = id;
@@ -98,6 +99,18 @@ public class LittleStructureType {
             ingredientRules = new ArrayList<>();
         ingredientRules.add(rule);
         return this;
+    }
+    
+    /** Add this method to Structure Type's register to prevent players in survival mode from importing this type of structure.
+     * 
+     * @return */
+    public LittleStructureType preventImportInSurvival() {
+        this.allowImport = false;
+        return this;
+    }
+    
+    public boolean canImport() {
+        return this.allowImport;
     }
     
     public LittleStructure createStructure(StructureTileList mainBlock) {


### PR DESCRIPTION
Adds an option to prevent a structure type from being imported by a player in survival mode. A message will pop up similar to the invalid grid size message box. The message will give the name of the structure type and state that it cannot be imported in survival mode.
Usage example:
`
LittleStructureRegistry
                    .registerStructureType("cam_player", "advance", LittleCamPlayerALET.class, LittleStructureAttribute.TICKING, LittleCamPlayerALET.LittleCamPlayerParserALET.class).preventImportInSurvival();
`