### PR TITLE
Ensures All doors in blueprint are saved as closed

### DIFF
--- a/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
@@ -24,6 +24,8 @@ import com.creativemd.littletiles.common.structure.LittleStructure;
 import com.creativemd.littletiles.common.structure.animation.AnimationGuiHandler;
 import com.creativemd.littletiles.common.structure.registry.LittleStructureGuiParser;
 import com.creativemd.littletiles.common.structure.registry.LittleStructureRegistry;
+import com.creativemd.littletiles.common.structure.registry.LittleStructureType;
+import com.creativemd.littletiles.common.structure.type.door.LittleDoorBase.LittleDoorBaseType;
 import com.creativemd.littletiles.common.tile.parent.StructureTileList;
 import com.creativemd.littletiles.common.tile.preview.LittlePreview;
 import com.creativemd.littletiles.common.tile.preview.LittlePreviews;
@@ -181,6 +183,7 @@ public class SubGuiRecipe extends SubGuiConfigure implements IAnimationControl {
         controls.add(new GuiButton("save", 150, 176, 40) {
             @Override
             public void onClicked(int x, int y, int button) {
+                clearOpenedDoors();
                 savePreview();
                 finializePreview(previews);
                 
@@ -197,6 +200,16 @@ public class SubGuiRecipe extends SubGuiConfigure implements IAnimationControl {
         controls.add(new GuiTextfield("name", "", 2, 176, 95, 14).setCustomTooltip(translate("selection.structure.name")));
         
         loadStack(hierarchy.get(0));
+    }
+    
+    private void clearOpenedDoors() {
+        for (StructureHolder holder : hierarchy) {
+            NBTTagCompound nbt = holder.previews.structureNBT;
+            String id = nbt.getString("id");
+            LittleStructureType type = LittleStructureRegistry.getStructureType(id);
+            if (type instanceof LittleDoorBaseType && nbt.hasKey("opened"))
+                nbt.setBoolean("opened", false);
+        }
     }
     
     public void loadStack(StructureHolder holder) {

--- a/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
@@ -204,6 +204,8 @@ public class SubGuiRecipe extends SubGuiConfigure implements IAnimationControl {
     
     private void clearOpenedDoors() {
         for (StructureHolder holder : hierarchy) {
+            if (selected == holder)
+                continue;
             NBTTagCompound nbt = holder.previews.structureNBT;
             String id = nbt.getString("id");
             LittleStructureType type = LittleStructureRegistry.getStructureType(id);

--- a/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
@@ -207,7 +207,9 @@ public class SubGuiRecipe extends SubGuiConfigure implements IAnimationControl {
             if (selected == holder)
                 continue;
             NBTTagCompound nbt = holder.previews.structureNBT;
-            if (nbt.hasKey("id"))
+            if (nbt == null)
+                continue;
+            if (!nbt.hasKey("id"))
                 continue;
             String id = nbt.getString("id");
             LittleStructureType type = LittleStructureRegistry.getStructureType(id);

--- a/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
+++ b/src/main/java/com/creativemd/littletiles/client/gui/SubGuiRecipe.java
@@ -207,6 +207,8 @@ public class SubGuiRecipe extends SubGuiConfigure implements IAnimationControl {
             if (selected == holder)
                 continue;
             NBTTagCompound nbt = holder.previews.structureNBT;
+            if (nbt.hasKey("id"))
+                continue;
             String id = nbt.getString("id");
             LittleStructureType type = LittleStructureRegistry.getStructureType(id);
             if (type instanceof LittleDoorBaseType && nbt.hasKey("opened"))


### PR DESCRIPTION
This is to fix a certain issue when saving an already opened door into a blueprint. It does not reset the NBT tag "opened" to false. It remaining true prevents it from opening properly.