### PR TITLE
Fixed compatibility with Oculus 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ minecraft {
 }
 
 dependencies {
-    implementation fg.deobf("curse.maven:oculus-581495:5108615")
+    implementation fg.deobf("curse.maven:oculus-581495:5299671")
     implementation fg.deobf("org.embeddedt:embeddium-1.20.1:0.3.9-git.f603a93+mc1.20.1")
     
     minecraft "net.minecraftforge:forge:${project.property 'minecraft_version'}-${project.property 'forge_version'}"

--- a/src/main/java/team/creative/littletiles/client/mod/oculus/OculusInteractor.java
+++ b/src/main/java/team/creative/littletiles/client/mod/oculus/OculusInteractor.java
@@ -1,9 +1,9 @@
 package team.creative.littletiles.client.mod.oculus;
 
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
-import net.coderbot.iris.compat.sodium.impl.block_context.ChunkBuildBuffersExt;
-import net.coderbot.iris.compat.sodium.impl.shader_overrides.ShaderChunkRendererExt;
-import net.coderbot.iris.vertices.ExtendedDataHelper;
+import net.irisshaders.iris.compat.sodium.impl.block_context.ChunkBuildBuffersExt;
+import net.irisshaders.iris.compat.sodium.impl.shader_overrides.ShaderChunkRendererExt;
+import net.irisshaders.iris.vertices.ExtendedDataHelper;
 import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.state.BlockState;
@@ -29,7 +29,7 @@ public class OculusInteractor {
     
     public static void setMaterialId(ChunkBuildBuffers buffers, BlockState state) {
         if (buffers instanceof ChunkBuildBuffersExt ext)
-            ext.iris$setMaterialId(state, ExtendedDataHelper.BLOCK_RENDER_TYPE);
+            ext.iris$setMaterialId(state, ExtendedDataHelper.BLOCK_RENDER_TYPE, (byte) 0);
     }
     
     public static void resetBlockContext(ChunkBuildBuffers buffers) {

--- a/src/main/java/team/creative/littletiles/client/mod/oculus/OculusSodiumInteractor.java
+++ b/src/main/java/team/creative/littletiles/client/mod/oculus/OculusSodiumInteractor.java
@@ -3,7 +3,7 @@ package team.creative.littletiles.client.mod.oculus;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexAttributeBinding;
 import me.jellysquid.mods.sodium.client.gl.attribute.GlVertexFormat;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkMeshAttribute;
-import net.coderbot.iris.compat.sodium.impl.vertex_format.IrisChunkMeshAttributes;
+import net.irisshaders.iris.compat.sodium.impl.vertex_format.IrisChunkMeshAttributes;
 
 public class OculusSodiumInteractor {
     

--- a/src/main/java/team/creative/littletiles/mixin/oculus/XHFPTerrainVertexMixin.java
+++ b/src/main/java/team/creative/littletiles/mixin/oculus/XHFPTerrainVertexMixin.java
@@ -5,8 +5,8 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import net.coderbot.iris.compat.sodium.impl.vertex_format.terrain_xhfp.XHFPTerrainVertex;
-import net.coderbot.iris.vertices.ExtendedDataHelper;
+import net.irisshaders.iris.compat.sodium.impl.vertex_format.terrain_xhfp.XHFPTerrainVertex;
+import net.irisshaders.iris.vertices.ExtendedDataHelper;
 import team.creative.creativecore.common.util.math.vec.Vec3d;
 
 @Mixin(XHFPTerrainVertex.class)
@@ -15,7 +15,7 @@ public class XHFPTerrainVertexMixin {
     @Unique
     public Vec3d center;
     
-    @Redirect(remap = false, at = @At(value = "INVOKE", target = "Lnet/coderbot/iris/vertices/ExtendedDataHelper;computeMidBlock(FFFIII)I"),
+    @Redirect(remap = false, at = @At(value = "INVOKE", target = "Lnet/irisshaders/iris/vertices/ExtendedDataHelper;computeMidBlock(FFFIII)I"),
             method = "write(JLme/jellysquid/mods/sodium/client/render/chunk/terrain/material/Material;Lme/jellysquid/mods/sodium/client/render/chunk/vertex/format/ChunkVertexEncoder$Vertex;I)J")
     public int computeMidBlock(float x, float y, float z, int localPosX, int localPosY, int localPosZ) {
         if (center != null)


### PR DESCRIPTION
This is to fix compatibility with Oculus 1.7.0

Only two changes were made:

* Changed the import path from coderbot to irisshaders
* Added the new required parameter to the iris$setMaterialId function