### PR TITLE
fix: recipe result count is not respected

### DIFF
--- a/src/main/java/team/creative/littletiles/common/item/ItemPremadeStructure.java
+++ b/src/main/java/team/creative/littletiles/common/item/ItemPremadeStructure.java
@@ -34,8 +34,7 @@ import team.creative.littletiles.common.structure.type.premade.LittleStructurePr
 
 public class ItemPremadeStructure extends Item implements ILittlePlacer, IItemTooltip {
     
-    public static ItemStack of(String structure) {
-        ItemStack stack = new ItemStack(LittleTilesRegistry.PREMADE.value());
+    public static ItemStack of(ItemStack stack, String structure) {
         CompoundTag nbt = new CompoundTag();
         CompoundTag structNbt = new CompoundTag();
         structNbt.putString("id", structure);

--- a/src/main/java/team/creative/littletiles/common/recipe/PremadeShapedRecipeSerializer.java
+++ b/src/main/java/team/creative/littletiles/common/recipe/PremadeShapedRecipeSerializer.java
@@ -6,6 +6,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapedRecipe;
@@ -17,7 +18,7 @@ public class PremadeShapedRecipeSerializer implements RecipeSerializer<ShapedRec
     public static final MapCodec<ShapedRecipe> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(Codec.STRING.optionalFieldOf("group", "").forGetter(x -> x
             .getGroup()), CraftingBookCategory.CODEC.fieldOf("category").orElse(CraftingBookCategory.MISC).forGetter(x -> x.category()), ShapedRecipePattern.MAP_CODEC.forGetter(
                 x -> x.pattern), Codec.STRING.fieldOf("structure").forGetter(x -> ""), Codec.BOOL.optionalFieldOf("show_notification", Boolean.valueOf(true)).forGetter(x -> x
-                        .showNotification())).apply(instance, (a, b, c, structure, e) -> new ShapedRecipe(a, b, c, ItemPremadeStructure.of(structure), e)));
+                        .showNotification()), ItemStack.CODEC.fieldOf("result").forGetter(x -> x.getResultItem(null))).apply(instance, (a, b, c, structure, e, result) -> new ShapedRecipe(a, b, c, ItemPremadeStructure.of(result, structure), e)));
     
     @Override
     public MapCodec<ShapedRecipe> codec() {

--- a/src/main/java/team/creative/littletiles/common/recipe/StructureIngredient.java
+++ b/src/main/java/team/creative/littletiles/common/recipe/StructureIngredient.java
@@ -42,7 +42,7 @@ public class StructureIngredient implements ICustomIngredient {
     
     @Override
     public Stream<ItemStack> getItems() {
-        return Stream.of(ItemPremadeStructure.of(structureType));
+        return Stream.of(ItemPremadeStructure.of(new ItemStack(LittleTilesRegistry.PREMADE), structureType));
     }
     
     @Override


### PR DESCRIPTION
fixed issue that premade recipes don't respect recipe result count property

![java  2025-04-09 at 11 36 35 AM](https://github.com/user-attachments/assets/75873b4c-01a8-48ec-b98f-4b59b0b23794)
