### PR TITLE
Fix Blueprint Thumbnail Rendering Issue in Inventory & Fix Blueprint Export Issue

### DIFF
--- a/src/main/java/team/creative/littletiles/client/LittleTilesClient.java
+++ b/src/main/java/team/creative/littletiles/client/LittleTilesClient.java
@@ -21,6 +21,7 @@ import net.minecraft.client.renderer.item.ItemProperties;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
@@ -330,12 +331,15 @@ public class LittleTilesClient {
         CreativeCoreClient.registerItemModel(ResourceLocation.tryBuild(LittleTiles.MODID, "chisel"), new LittleModelItemPreview(new ModelResourceLocation(ResourceLocation.tryBuild(
             LittleTiles.MODID, "chisel_background"), ModelResourceLocation.STANDALONE_VARIANT), stack -> LittleElement.getOrDefault(stack)));
         
-        CreativeCoreClient.registerItemModel(ResourceLocation.tryBuild(LittleTiles.MODID, "blueprint"), new LittleModelItemBackground(new ModelResourceLocation(ResourceLocation
-                .tryBuild(LittleTiles.MODID, "blueprint_background"), ModelResourceLocation.STANDALONE_VARIANT), x -> {
-                    if (!LittleGroup.shouldRenderInHand(ItemLittleBlueprint.getContent(x)))
+        CreativeCoreClient.registerItemModel(ResourceLocation.tryBuild(LittleTiles.MODID, "blueprint"),
+        new LittleModelItemBackground(new ModelResourceLocation(ResourceLocation
+                .tryBuild(LittleTiles.MODID, "blueprint_background"), ModelResourceLocation.STANDALONE_VARIANT),
+                x -> {
+                    CompoundTag contentData = ItemLittleBlueprint.getContent(x);
+                    if (!LittleGroup.shouldRenderInHand(contentData))
                         return ItemStack.EMPTY;
                     ItemStack stack = new ItemStack(LittleTilesRegistry.ITEM_TILES.value());
-                    ILittleTool.setData(stack, ILittleTool.getData(x));
+                    ILittleTool.setData(stack, contentData);
                     return stack;
                 }));
         

--- a/src/main/java/team/creative/littletiles/common/item/ItemLittleBlueprint.java
+++ b/src/main/java/team/creative/littletiles/common/item/ItemLittleBlueprint.java
@@ -74,7 +74,9 @@ public class ItemLittleBlueprint extends Item implements ILittlePlacer, IItemToo
     }
     
     public void saveTiles(ItemStack stack, LittleGroup group) {
-        ILittleTool.setData(stack, LittleGroup.save(group));
+        CompoundTag stackTag = ILittleTool.getData(stack);
+        stackTag.put(ItemLittleBlueprint.CONTENT_KEY, LittleGroup.save(group));
+        ILittleTool.setData(stack, stackTag);
     }
     
     @Override


### PR DESCRIPTION
In the current `a9c2296` commit on the 1.21 branch, the following bugs were observed:

We currently have SNBT code that can only be obtained by setting a debugging breakpoint:

```snbt
{boxes:1,min:[I;0,0,1],size:[I;15,16,15],t:{"minecraft:lime_wool":[[I;-1],[I;0,0,1,15,16,16,-2113929214,-1048576]]},tiles:1}
```

### Bug 1: Fix Blueprint Thumbnail Rendering Missing in Inventory

Blueprint A, directly imported into the game through code, was placed in inventory slot 1.
Blueprint B, saved from the in-game structure selection, was placed in inventory slot 2.

![image](https://github.com/user-attachments/assets/b2189e18-3720-452e-b7be-54eef9c6d5e3)

At this point, Blueprint A was observed to have rendering issues, while Blueprint B rendered correctly.

### Bug 2: Fix Blueprint Export Failure

Again, with Blueprints A and B, a more puzzling bug was found when opening the export window:

![image](https://github.com/user-attachments/assets/313e7707-a893-4d13-89ec-4372a97d3e4a)

Only the blueprint directly imported through code (Blueprint A) has an exported SNBT code, whereas the blueprint saved from structure (Blueprint B) only shows a pair of curly braces `{}` and fails to export the code.

### Fix Applied:

After investigation, it was determined that both bugs were caused by missing code to handle `ItemLittleBlueprint` with the `CONTENT_KEY = "c"`, leading to the differences, such as:

```snbt
// Blueprint A's breakpoint information
{littletiles:
  tool_config=>{
    c:{
      boxes:1,min:[I;0,0,1],size:[I;15,16,15],
      t:{"minecraft:lime_wool":[[I;-1],[I;0,0,1,15,16,16]]},tiles:1}}, 
...
// Blueprint B's breakpoint information
{littletiles:
  tool_config=>{
    boxes:1,min:[I;1,0,1],size:[I;15,16,15],
    t:{"minecraft:lime_wool":[[I;-1],[I;1,0,1,16,16,16]]},tiles:1}, 
...
```

By modifying some parts of the code, the issue has now been resolved:

![image](https://github.com/user-attachments/assets/1e020679-6e18-415f-827d-6896ff7e1d45)

![image](https://github.com/user-attachments/assets/53616ab0-1a43-426a-98c0-50300714383f)

---

Additionally, I'd like to ask for advice regarding code formatting. I use VSCode for development and am ready to continue contributing and maintaining the code. However, due to differences in IDE code formatting, I'm unsure if there are any formatting rules that could help eliminate these discrepancies.