### PR TITLE
[Fix] Added null check for BETiles.SideSolidCache.calculateState

### DIFF
--- a/src/main/java/team/creative/littletiles/common/block/entity/BETiles.java
+++ b/src/main/java/team/creative/littletiles/common/block/entity/BETiles.java
@@ -1007,6 +1007,10 @@ public class BETiles extends BlockEntityCreative implements IGridBased, ILittleB
         }
         
         public SideState calculateState(Facing facing, LittleBox box) {
+            if (BETiles.this.tiles == null) {
+                return SideState.EMPTY;
+            }
+
             LittleVec size = box.getSize();
             boolean[][][] filled = new boolean[size.x][size.y][size.z];
             


### PR DESCRIPTION
This PR added null check for `BETiles.SideSolidCache.calculateState` to avoid potential NPE (occured randomly when interacting with doors)

Assuming we could return a `SideState.EMPTY` safely